### PR TITLE
Recent items fixes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ class AnyList extends EventEmitter {
 
 		decoded.starterListsResponse.recentItemListsResponse.listResponses.forEach(response => {
 			const list = response.starterList;
-			this.recentItems[list.identifier] = list.items.map(item => {
+			this.recentItems[list.listId] = list.items.map(item => {
 				return new Item(item, this);
 			});
 		});
@@ -160,6 +160,15 @@ class AnyList extends EventEmitter {
    */
 	getListByName(name) {
 		return this.lists.find(l => l.name === name);
+	}
+
+	/**
+   * Get the recently added items for a list
+   * @param {string} listId list ID
+   * @return {Item[]} recently added items array
+   */
+	getRecentItemsByListId(listId) {
+		return this.recentItems[listId]
 	}
 
 	/**

--- a/lib/item.js
+++ b/lib/item.js
@@ -152,7 +152,7 @@ class Item {
 	}
 
 	get categoryMatchId() {
-		return this.categoryMatchId;
+		return this._categoryMatchId;
 	}
 
 	set categoryMatchId(i) {


### PR DESCRIPTION
- Use listId instead of identifier so that the ID of the recent items list corresponds to the ID of the actual shopping list
- Add getter for recent items list by list id
- Fix typo for categoryMatchId in item.js that causes stackoverflow 😛 