### PR TITLE
Added underscore prefix to return variable in getter for categoryMatchId

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -152,7 +152,7 @@ class Item {
 	}
 
 	get categoryMatchId() {
-		return this.categoryMatchId;
+		return this._categoryMatchId;
 	}
 
 	set categoryMatchId(i) {


### PR DESCRIPTION
Thank you for reverse engineering the anylist API and creating this repo - it helped me a lot!!  

While using it, I noticed a missing underscore prefix on the return variable in the getter for categoryMatchId so I added it and figured I'd contribute the change.

Thanks again!