### PR TITLE
fix authentication

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@ const got = require('got');
 const WebSocket = require('reconnecting-websocket');
 const WS = require('ws');
 const protobuf = require('protobufjs');
-const {CookieJar} = require('tough-cookie');
 const FormData = require('form-data');
 const definitions = require('./definitions.json');
 const List = require('./list');
@@ -31,8 +30,6 @@ class AnyList extends EventEmitter {
 		this.email = email;
 		this.password = password;
 
-		this.cookieJar = new CookieJar();
-
 		this.clientId = uuid();
 
 		this.client = got.extend({
@@ -41,18 +38,21 @@ class AnyList extends EventEmitter {
 				'X-AnyLeaf-Client-Identifier': this.clientId
 			},
 			prefixUrl: 'https://www.anylist.com',
-			cookieJar: this.cookieJar,
 			followRedirect: false,
 			hooks: {
 				beforeRequest: [
 					options => {
 						const url = options.url.href;
-						if (url.includes('data') && !url.includes('data/validate-login')) {
-							options.responseType = 'buffer';
+						if (!url.includes("/auth/token")) {
 							options.headers = {
-								'X-AnyLeaf-Signed-User-ID': this.signedUserId,
+								'authorization': `Bearer ${this.token}`,
+								'x-anyleaf-client-identifier': this.clientId,
 								...options.headers
 							};
+						}
+
+						if (url.includes('/data/')) {
+							options.responseType = 'buffer';
 						}
 					}
 				]
@@ -72,25 +72,26 @@ class AnyList extends EventEmitter {
    * in the constructor.
    */
 	async login() {
-		// Authentication is saved in cookie jar
 		const form = new FormData();
-
 		form.append('email', this.email);
 		form.append('password', this.password);
 
-		const result = await this.client.post('data/validate-login', {
+		const result = await this.client.post('auth/token', {
 			body: form
 		}).json();
 
-		this.signedUserId = result.signed_user_id;
 		this.uid = result.user_id;
+		this.token = result.access_token;
 
 		this._setupWebSocket();
 	}
 
 	_setupWebSocket() {
-		this.ws = new WebSocket(`wss://www.anylist.com/data/add-user-listener/${this.signedUserId}?client_id=${this.clientId}`, [], {
-			WebSocket: WS
+		AuthenticatedWebSocket.token = this.token;
+		AuthenticatedWebSocket.clientId = this.clientId;
+
+		this.ws = new WebSocket(`wss://www.anylist.com/data/add-user-listener`, [], {
+			WebSocket: AuthenticatedWebSocket
 		});
 
 		this.ws.addEventListener('open', () => {
@@ -102,13 +103,13 @@ class AnyList extends EventEmitter {
 		this.ws.addEventListener('message', async ({data}) => {
 			if (data === 'refresh-shopping-lists') {
 				/**
-		 * Lists update event
-		 * (fired when any list is modified by an outside actor).
-		 * The instance's `.lists` are updated before the event fires.
-		 *
-		 * @event AnyList#lists-update
-		 * @type {List[]} updated lists
-		 */
+				 * Lists update event
+				 * (fired when any list is modified by an outside actor).
+				 * The instance's `.lists` are updated before the event fires.
+				 *
+				 * @event AnyList#lists-update
+				 * @type {List[]} updated lists
+				 */
 				this.emit('lists-update', await this.getLists());
 			}
 		});
@@ -213,6 +214,21 @@ class AnyList extends EventEmitter {
    */
 	createRecipeCollection(recipeCollection) {
 		return new RecipeCollection(recipeCollection, this);
+	}
+}
+
+class AuthenticatedWebSocket extends WS {
+
+	static token;
+	static clientId;
+
+	constructor(url, protocols) {
+		super(url, protocols, {
+			headers: {
+				'authorization': `Bearer ${AuthenticatedWebSocket.token}`,
+				'x-anyleaf-client-identifier': AuthenticatedWebSocket.clientId
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
Anylist made some changes to how clients are authenticated. They are now using bearer tokens instead of cookie based authentication so we have to include it in the header of every request. 

The tricky part is including the token in the WS request since reconnecting-websocket does not pass headers to the underlying WS implementation. 