### PR TITLE
Add Meal Planning Calendar Events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events');
 const crypto = require('crypto');
 const fs = require('fs');
-const os = require("os");
+const os = require('os');
 const path = require('path');
 const {Buffer} = require('buffer');
 const got = require('got');
@@ -55,7 +55,7 @@ class AnyList extends EventEmitter {
 						const url = response.request.options.url.href;
 						console.error(`Endpoint ${url} returned uncaught status code ${response.statusCode}`);
 						return error;
-					}
+					},
 				],
 			},
 		});
@@ -100,7 +100,7 @@ class AnyList extends EventEmitter {
 						const url = response.request.options.url.href;
 						console.error(`Endpoint ${url} returned uncaught status code ${response.statusCode}`);
 						return error;
-					}
+					},
 				],
 			},
 		});
@@ -270,6 +270,7 @@ class AnyList extends EventEmitter {
 			}
 		});
 
+		// eslint-disable-next-line arrow-parens
 		this.ws.addEventListener('error', async (error) => {
 			console.error(`Disconnected from websocket: ${error.message}`);
 			await this._refreshTokens();

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ const Item = require('./item');
 const uuid = require('./uuid');
 const Recipe = require('./recipe');
 const RecipeCollection = require('./recipe-collection');
+const MealPlanningCalendarEvent = require('./meal-planning-calendar-event');
+const MealPlanningCalendarEventLabel = require('./meal-planning-calendar-label');
 
 const CREDENTIALS_KEY_CLIENT_ID = 'clientId';
 const CREDENTIALS_KEY_ACCESS_TOKEN = 'accessToken';
@@ -322,6 +324,32 @@ class AnyList extends EventEmitter {
    */
 	getListByName(name) {
 		return this.lists.find(l => l.name === name);
+	}
+
+	/**
+   * Load all meal planning calendar events from account into memory.
+   * @return {Promise<MealPlanningCalendarEvent[]>} events
+   */
+	async getMealPlanningCalendarEvents() {
+		const result = await this.client.post('data/user-data/get');
+
+		const decoded = this.protobuf.PBUserDataResponse.decode(result.body);
+
+		this.mealPlanningCalendarEvents = decoded.mealPlanningCalendarResponse.events.map(event => new MealPlanningCalendarEvent(event, this));
+
+		// Map and assign labels
+		this.mealPlanningCalendarEventLabels = decoded.mealPlanningCalendarResponse.labels.map(label => new MealPlanningCalendarEventLabel(label));
+		for (const event of this.mealPlanningCalendarEvents) {
+			event.label = this.mealPlanningCalendarEventLabels.find(label => label.identifier === event.labelId);
+		}
+
+		// Map and assign recipies
+		this.recipes = decoded.recipeDataResponse.recipes.map(recipe => new Recipe(recipe, this));
+		for (const event of this.mealPlanningCalendarEvents) {
+			event.recipe = this.recipes.find(recipe => recipe.identifier === event.recipeId);
+		}
+
+		return this.mealPlanningCalendarEvents;
 	}
 
 	/**

--- a/lib/meal-planning-calendar-event.js
+++ b/lib/meal-planning-calendar-event.js
@@ -1,0 +1,45 @@
+/// <reference path="./meal-planning-calendar-label.js" />
+
+/**
+ * Meal Planning Calendar Event class.
+ * @class
+ *
+ * @param {object} event event
+ * @param {object[]} labels labels
+ * @param {object} context context
+ *
+ * @property {string} identifier
+ * @property {string} calendarId
+ * @property {Date} date
+ * @property {string=} details
+ * @property {string=} labelId
+ * @property {MealPlanningCalendarEventLabel} label
+ * @property {number} logicalTimestamp
+ * @property {number} orderAddedSortIndex
+ * @property {string} recipeId
+ * @property {number} recipeScaleFactor
+ * @property {string=} title
+ */
+class MealPlanningCalendarEvent {
+	/**
+   * @hideconstructor
+   */
+	constructor(event, {client, protobuf, uid}) {
+		this.identifier = event.identifier;
+		this.calendarId = event.calendarId;
+		this.date = new Date(event.date);
+		this.details = event.details;
+		this.labelId = event.labelId;
+		this.logicalTimestamp = event.logicalTimestamp;
+		this.orderAddedSortIndex = event.orderAddedSortIndex;
+		this.recipeId = event.recipeId;
+		this.recipeScaleFactor = event.recipeScaleFactor;
+		this.title = event.title;
+
+		this.client = client;
+		this.protobuf = protobuf;
+		this.uid = uid;
+	}
+}
+
+module.exports = MealPlanningCalendarEvent;

--- a/lib/meal-planning-calendar-event.js
+++ b/lib/meal-planning-calendar-event.js
@@ -1,4 +1,5 @@
 /// <reference path="./meal-planning-calendar-label.js" />
+/// <reference path="./recipe.js" />
 
 /**
  * Meal Planning Calendar Event class.
@@ -13,11 +14,12 @@
  * @property {Date} date
  * @property {string=} details
  * @property {string=} labelId
- * @property {MealPlanningCalendarEventLabel} label
- * @property {number} logicalTimestamp
- * @property {number} orderAddedSortIndex
- * @property {string} recipeId
- * @property {number} recipeScaleFactor
+ * @property {MealPlanningCalendarEventLabel=} label
+ * @property {number=} logicalTimestamp
+ * @property {number=} orderAddedSortIndex
+ * @property {string=} recipeId
+ * @property {Recipe=} recipe
+ * @property {number=} recipeScaleFactor
  * @property {string=} title
  */
 class MealPlanningCalendarEvent {
@@ -35,6 +37,8 @@ class MealPlanningCalendarEvent {
 		this.recipeId = event.recipeId;
 		this.recipeScaleFactor = event.recipeScaleFactor;
 		this.title = event.title;
+		this.recipe = null;
+		this.label = null;
 
 		this.client = client;
 		this.protobuf = protobuf;

--- a/lib/meal-planning-calendar-label.js
+++ b/lib/meal-planning-calendar-label.js
@@ -1,0 +1,29 @@
+/**
+ * Meal Planning Calendar Event Label class.
+ * @class
+ *
+ * @param {object} label label
+ *
+ * @property {string} identifier
+ * @property {string} calendarId
+ * @property {string} hexColor
+ * @property {number} logicalTimestamp
+ * @property {string} name
+ * @property {number} sortIndex
+ *
+ */
+class MealPlanningCalendarEventLabel {
+	/**
+   * @hideconstructor
+   */
+	constructor(label) {
+		this.identifier = label.identifier;
+		this.calendarId = label.calendarId;
+		this.hexColor = label.hexColor;
+		this.logicalTimestamp = label.logicalTimestamp;
+		this.name = label.name;
+		this.sortIndex = label.sortIndex;
+	}
+}
+
+module.exports = MealPlanningCalendarEventLabel;


### PR DESCRIPTION
Add support for Meal Planning Calendar Events.

> NOTE: current draft PR only implements reading of existing calendar events; still working on creating/updating/deleting them.


First commit in the branch also fixes a few eslint issues that were keeping me from committing; happy to make another branch/PR for those if that helps.