### PR TITLE
Refactor retrieval of user data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,7 @@ class AnyList extends EventEmitter {
 		this.recentItems = {};
 		this.recipes = [];
 		this.recipeDataId = null;
+		this._userData = null;
 	}
 
 	/**
@@ -260,6 +261,7 @@ class AnyList extends EventEmitter {
 		this.ws.addEventListener('message', async ({data}) => {
 			if (data === 'refresh-shopping-lists') {
 				console.info('Refreshing shopping lists');
+				
 				/**
 				 * Lists update event
 				 * (fired when any list is modified by an outside actor).
@@ -293,8 +295,8 @@ class AnyList extends EventEmitter {
    * Load all lists from account into memory.
    * @return {Promise<List[]>} lists
    */
-	async getLists() {
-		const decoded = await this._getUserData();
+	async getLists(refreshCache = true) {
+		const decoded = await this._getUserData(refreshCache);
 
 		this.lists = decoded.shoppingListsResponse.newLists.map(list => new List(list, this));
 
@@ -328,8 +330,8 @@ class AnyList extends EventEmitter {
    * Load all meal planning calendar events from account into memory.
    * @return {Promise<MealPlanningCalendarEvent[]>} events
    */
-	async getMealPlanningCalendarEvents() {
-		const decoded = await this._getUserData();
+	async getMealPlanningCalendarEvents(refreshCache = true) {
+		const decoded = await this._getUserData(refreshCache);
 
 		this.mealPlanningCalendarEvents = decoded.mealPlanningCalendarResponse.events.map(event => new MealPlanningCalendarEvent(event, this));
 
@@ -370,8 +372,8 @@ class AnyList extends EventEmitter {
    * Load all recipes from account into memory.
    * @return {Promise<Recipe[]>} recipes
 	*/
-	async getRecipes() {
-		const decoded = await this._getUserData();
+	async getRecipes(refreshCache = true) {
+		const decoded = await this._getUserData(refreshCache);
 
 		this.recipes = decoded.recipeDataResponse.recipes.map(recipe => new Recipe(recipe, this));
 		this.recipeDataId = decoded.recipeDataResponse.recipeDataId;
@@ -400,9 +402,13 @@ class AnyList extends EventEmitter {
 		return new RecipeCollection(recipeCollection, this);
 	}
 
-	async _getUserData() {
-		const result = await this.client.post('data/user-data/get');
-		return this.protobuf.PBUserDataResponse.decode(result.body);
+	async _getUserData(refreshCache) {
+		if(!this._userData || refreshCache) {
+			const result = await this.client.post('data/user-data/get');
+			this._userData = this.protobuf.PBUserDataResponse.decode(result.body);
+		}
+
+		return this._userData;
 	}
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,9 +294,7 @@ class AnyList extends EventEmitter {
    * @return {Promise<List[]>} lists
    */
 	async getLists() {
-		const result = await this.client.post('data/user-data/get');
-
-		const decoded = this.protobuf.PBUserDataResponse.decode(result.body);
+		const decoded = await this._getUserData();
 
 		this.lists = decoded.shoppingListsResponse.newLists.map(list => new List(list, this));
 
@@ -331,9 +329,7 @@ class AnyList extends EventEmitter {
    * @return {Promise<MealPlanningCalendarEvent[]>} events
    */
 	async getMealPlanningCalendarEvents() {
-		const result = await this.client.post('data/user-data/get');
-
-		const decoded = this.protobuf.PBUserDataResponse.decode(result.body);
+		const decoded = await this._getUserData();
 
 		this.mealPlanningCalendarEvents = decoded.mealPlanningCalendarResponse.events.map(event => new MealPlanningCalendarEvent(event, this));
 
@@ -375,8 +371,7 @@ class AnyList extends EventEmitter {
    * @return {Promise<Recipe[]>} recipes
 	*/
 	async getRecipes() {
-		const result = await this.client.post('data/user-data/get');
-		const decoded = this.protobuf.PBUserDataResponse.decode(result.body);
+		const decoded = await this._getUserData();
 
 		this.recipes = decoded.recipeDataResponse.recipes.map(recipe => new Recipe(recipe, this));
 		this.recipeDataId = decoded.recipeDataResponse.recipeDataId;
@@ -403,6 +398,11 @@ class AnyList extends EventEmitter {
    */
 	createRecipeCollection(recipeCollection) {
 		return new RecipeCollection(recipeCollection, this);
+	}
+
+	async _getUserData() {
+		const result = await this.client.post('data/user-data/get');
+		return this.protobuf.PBUserDataResponse.decode(result.body);
 	}
 }
 


### PR DESCRIPTION
As it stands, all of the existing `get*` methods all `GET` from the same endpoint, which retrieves ALL user data every time.
This PR refactors that to one method (in the first commit), and then also implements optional in-memory "caching" of the user data to avoid getting it every call.

NOTE: this implementation defaults to the existing behavior, which is to re-fetch the user data with every call, though adds an optional parameter to override this and use the cached data.  Seemed prudent to make this change backwards-compatible, but if you're into making the default to use the cached data, that'd be cool!