### PR TITLE
Remove quantity field from Item._encode()

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -68,7 +68,6 @@ class Item {
 			identifier: this._identifier,
 			listId: this._listId,
 			name: this._name,
-			quantity: this._quantity,
 			details: this._details,
 			checked: this._checked,
 			category: this._category,


### PR DESCRIPTION
## Summary
The `quantity` field does not exist in the `ListItem` protobuf schema (see `lib/definitions.json`). Including it in `_encode()` causes protobuf encoding errors when calling methods like `removeItem()` that need to encode the item.

## Problem
When trying to remove an item from a list using `list.removeItem(item)`, the following error occurs:
```
.pcov.proto.ListItem#quantity is not a field: undefined
```

This happens because `_encode()` tries to include `quantity: this._quantity` but the protobuf schema for `ListItem` doesn't have a `quantity` field.

## Solution
Remove the `quantity` field from the `_encode()` method since it's not part of the protobuf schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)