### PR TITLE
feat: add calendar label CRUD operations and expose recipe collections

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class AnyList extends EventEmitter {
 							const url = response.request.options.url.href;
 							console.error(`Endpoint ${url} returned uncaught status code ${response.statusCode}`);
 						}
+
 						return error;
 					},
 				],
@@ -116,6 +117,7 @@ class AnyList extends EventEmitter {
 		this.favoriteItems = [];
 		this.recentItems = {};
 		this.recipes = [];
+		this.recipeCollections = [];
 		this.recipeDataId = null;
 		this._userData = null;
 		this.calendarId = null;
@@ -362,7 +364,7 @@ class AnyList extends EventEmitter {
 		this.mealPlanningCalendarEvents = decoded.mealPlanningCalendarResponse.events.map(event => new MealPlanningCalendarEvent(event, this));
 
 		// Map and assign labels
-		this.mealPlanningCalendarEventLabels = decoded.mealPlanningCalendarResponse.labels.map(label => new MealPlanningCalendarEventLabel(label));
+		this.mealPlanningCalendarEventLabels = decoded.mealPlanningCalendarResponse.labels.map(label => new MealPlanningCalendarEventLabel(label, this));
 		for (const event of this.mealPlanningCalendarEvents) {
 			event.label = this.mealPlanningCalendarEventLabels.find(label => label.identifier === event.labelId);
 		}
@@ -408,6 +410,19 @@ class AnyList extends EventEmitter {
 	}
 
 	/**
+	 * Factory function to create a new MealPlanningCalendarEventLabel.
+	 * @param {object} label new label options (name, hexColor, sortIndex).
+	 * @return {Promise<MealPlanningCalendarEventLabel>} label
+	 */
+	async createLabel(labelObject) {
+		if (!this.calendarId) {
+			await this._getUserData();
+		}
+
+		return new MealPlanningCalendarEventLabel(labelObject, this);
+	}
+
+	/**
    * Load all recipes from account into memory.
    * @return {Promise<Recipe[]>} recipes
 	*/
@@ -415,6 +430,9 @@ class AnyList extends EventEmitter {
 		const decoded = await this._getUserData(refreshCache);
 
 		this.recipes = decoded.recipeDataResponse.recipes.map(recipe => new Recipe(recipe, this));
+		this.recipeCollections = (decoded.recipeDataResponse.recipeCollections || []).map(
+			collection => new RecipeCollection(collection, this),
+		);
 		this.recipeDataId = decoded.recipeDataResponse.recipeDataId;
 		return this.recipes;
 	}
@@ -439,6 +457,38 @@ class AnyList extends EventEmitter {
    */
 	createRecipeCollection(recipeCollection) {
 		return new RecipeCollection(recipeCollection, this);
+	}
+
+	/**
+   * Load all recipe collections from account into memory.
+   * @return {Promise<RecipeCollection[]>} recipe collections
+   */
+	async getRecipeCollections(refreshCache = true) {
+		const decoded = await this._getUserData(refreshCache);
+
+		this.recipeCollections = (decoded.recipeDataResponse.recipeCollections || []).map(
+			collection => new RecipeCollection(collection, this),
+		);
+		this.recipeDataId = decoded.recipeDataResponse.recipeDataId;
+		return this.recipeCollections;
+	}
+
+	/**
+   * Get RecipeCollection instance by ID.
+   * @param {string} identifier collection ID
+   * @return {RecipeCollection} collection
+   */
+	getRecipeCollectionById(identifier) {
+		return this.recipeCollections.find(c => c.identifier === identifier);
+	}
+
+	/**
+   * Get RecipeCollection instance by name.
+   * @param {string} name collection name
+   * @return {RecipeCollection} collection
+   */
+	getRecipeCollectionByName(name) {
+		return this.recipeCollections.find(c => c.name === name);
 	}
 
 	async _getUserData(refreshCache) {

--- a/lib/meal-planning-calendar-label.js
+++ b/lib/meal-planning-calendar-label.js
@@ -1,8 +1,12 @@
+const FormData = require('form-data');
+const uuid = require('./uuid');
+
 /**
  * Meal Planning Calendar Event Label class.
  * @class
  *
  * @param {object} label label
+ * @param {object} context context
  *
  * @property {string} identifier
  * @property {string} calendarId
@@ -16,13 +20,76 @@ class MealPlanningCalendarEventLabel {
 	/**
    * @hideconstructor
    */
-	constructor(label) {
-		this.identifier = label.identifier;
-		this.calendarId = label.calendarId;
+	constructor(label, {client, protobuf, uid, calendarId} = {}) {
+		this.identifier = label.identifier || uuid();
+		this.calendarId = label.calendarId || calendarId;
 		this.hexColor = label.hexColor;
 		this.logicalTimestamp = label.logicalTimestamp;
 		this.name = label.name;
 		this.sortIndex = label.sortIndex;
+
+		this._client = client;
+		this._protobuf = protobuf;
+		this._uid = uid;
+		this._isNew = !label.identifier;
+		this._calendarId = calendarId;
+	}
+
+	_encode() {
+		return new this._protobuf.PBCalendarLabel({
+			identifier: this.identifier,
+			logicalTimestamp: this.logicalTimestamp,
+			calendarId: this._calendarId,
+			hexColor: this.hexColor,
+			name: this.name,
+			sortIndex: this.sortIndex,
+		});
+	}
+
+	/**
+	 * Perform a calendar label operation.
+	 * @private
+	 * @param {string} handlerId - Handler ID for the operation
+	 * @returns {Promise} - Promise representing the operation result
+	 */
+	async performOperation(handlerId) {
+		const ops = new this._protobuf.PBCalendarOperationList();
+		const op = new this._protobuf.PBCalendarOperation();
+
+		op.setMetadata({
+			operationId: uuid(),
+			handlerId,
+			userId: this._uid,
+		});
+
+		op.setCalendarId(this._calendarId);
+		op.setUpdatedLabel(this._encode());
+		ops.setOperations([op]);
+
+		const form = new FormData();
+
+		form.append('operations', ops.toBuffer());
+		await this._client.post('data/meal-planning-calendar/update', {
+			body: form,
+		});
+	}
+
+	/**
+	 * Save local changes to the calendar label to AnyList's API.
+	 * @return {Promise}
+	 */
+	async save() {
+		const operation = this._isNew ? 'new-label' : 'update-label';
+		await this.performOperation(operation);
+		this._isNew = false;
+	}
+
+	/**
+	 * Delete this label from the calendar via AnyList's API.
+	 * @return {Promise}
+	 */
+	async delete() {
+		await this.performOperation('delete-label');
 	}
 }
 


### PR DESCRIPTION
Calendar Labels:
- Add save() method supporting both create (new-label) and update (update-label)
- Add delete() method (delete-label handler)
- Add _encode() to serialize label back to PBCalendarLabel protobuf
- Add performOperation() for sending PBCalendarOperationList to the API
- Accept client context (client, protobuf, uid, calendarId) in constructor
- Track new vs existing labels via _isNew flag for correct handler selection

Recipe Collections:
- Populate recipeCollections from PBRecipeDataResponse in getRecipes()
- Add getRecipeCollections() to fetch/refresh and return all collections
- Add getRecipeCollectionById() and getRecipeCollectionByName() helpers
- Recipe collection data was already fetched but discarded; now retained

Other:
- Pass full client context to MealPlanningCalendarEventLabel constructors
- Add createLabel() factory method for creating new labels with context
- Fix pre-existing xo lint error (missing blank line before return)