### PR TITLE
feat(item): expose recipeId, rawIngredient, and ingredients

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class AnyList extends EventEmitter {
 							const url = response.request.options.url.href;
 							console.error(`Endpoint ${url} returned uncaught status code ${response.statusCode}`);
 						}
+
 						return error;
 					},
 				],

--- a/lib/item.js
+++ b/lib/item.js
@@ -26,6 +26,9 @@ const OP_MAPPING = {
  * @property {string} manualSortIndex
  * @property {string} userId
  * @property {string} categoryMatchId
+ * @property {string} recipeId
+ * @property {string} rawIngredient
+ * @property {Array<{recipeId: string, recipeName: string, eventId: string, eventDate: string}>} ingredients
  */
 class Item {
 	/**
@@ -41,6 +44,14 @@ class Item {
 		this._manualSortIndex = i.manualSortIndex;
 		this._userId = i.userId;
 		this._categoryMatchId = i.categoryMatchId || 'other';
+		this._recipeId = i.recipeId || null;
+		this._rawIngredient = i.rawIngredient || null;
+		this._ingredients = (i.ingredients || []).map(ing => ({
+			recipeId: ing.recipeId || null,
+			recipeName: ing.recipeName || null,
+			eventId: ing.eventId || null,
+			eventDate: ing.eventDate || null,
+		}));
 
 		this._client = client;
 		this._protobuf = protobuf;
@@ -60,6 +71,9 @@ class Item {
 			manualSortIndex: this._manualSortIndex,
 			userId: this._userId,
 			categoryMatchId: this._categoryMatchId,
+			recipeId: this._recipeId,
+			rawIngredient: this._rawIngredient,
+			ingredients: this._ingredients,
 		};
 	}
 
@@ -75,6 +89,9 @@ class Item {
 			userId: this._userId,
 			categoryMatchId: this._categoryMatchId,
 			manualSortIndex: this._manualSortIndex,
+			recipeId: this._recipeId,
+			rawIngredient: this._rawIngredient,
+			ingredients: this._ingredients,
 		});
 	}
 
@@ -158,6 +175,30 @@ class Item {
 	set categoryMatchId(i) {
 		this._categoryMatchId = i;
 		this._fieldsToUpdate.push('categoryMatchId');
+	}
+
+	get recipeId() {
+		return this._recipeId;
+	}
+
+	set recipeId(_) {
+		throw new Error('Recipe ID is read-only.');
+	}
+
+	get rawIngredient() {
+		return this._rawIngredient;
+	}
+
+	set rawIngredient(_) {
+		throw new Error('Raw ingredient is read-only.');
+	}
+
+	get ingredients() {
+		return this._ingredients;
+	}
+
+	set ingredients(_) {
+		throw new Error('Ingredients is read-only.');
 	}
 
 	get manualSortIndex() {


### PR DESCRIPTION
## Summary

- Expose `recipeId`, `rawIngredient`, and `ingredients` on the `Item` class
- These fields are already present in the protobuf `ListItem` definition but were not surfaced by the JS class
- `recipeId` and `rawIngredient` identify the recipe an item was added from
- `ingredients` is an array tracking multiple recipe sources when items are merged (each entry has `recipeId`, `recipeName`, `eventId`, `eventDate`)
- All three properties are read-only, following the same pattern as `identifier` and `userId`

## Motivation

The AnyList UI shows which recipe an item was added from, but this data was inaccessible through the package. The protobuf layer already deserializes these fields — they just needed to be wired up in the `Item` constructor, getters, `toJSON()`, and `_encode()`.

## Changes

- `lib/item.js`: Added constructor initialization, read-only getters with throwing setters, JSDoc `@property` tags, and serialization support in both `toJSON()` and `_encode()`
- `lib/index.js`: Fixed pre-existing lint error (missing blank line)

## Test plan

- [x] Verified `xo` linter passes
- [x] Verified `documentation build` succeeds (via pre-commit hook)
- [x] Live-tested against real AnyList account — 724 of 4,077 items returned valid `recipeId` and `rawIngredient` values