### PR TITLE
reverse-engineered fix for update/create/delete recipes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,24 @@ const CREDENTIALS_KEY_CLIENT_ID = 'clientId';
 const CREDENTIALS_KEY_ACCESS_TOKEN = 'accessToken';
 const CREDENTIALS_KEY_REFRESH_TOKEN = 'refreshToken';
 
+function decodeJwtSubject(token) {
+	if (!token || typeof token !== 'string') {
+		return null;
+	}
+
+	const parts = token.split('.');
+	if (parts.length < 2) {
+		return null;
+	}
+
+	try {
+		const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+		return typeof payload.sub === 'string' ? payload.sub : null;
+	} catch {
+		return null;
+	}
+}
+
 /**
  * AnyList class. There should be one
  * instance per account.
@@ -134,6 +152,8 @@ class AnyList extends EventEmitter {
 			await this._fetchTokens();
 		}
 
+		this.uid = decodeJwtSubject(this.accessToken);
+
 		if (connectWebSocket) {
 			this._setupWebSocket();
 		}
@@ -164,6 +184,7 @@ class AnyList extends EventEmitter {
 
 			this.accessToken = result.access_token;
 			this.refreshToken = result.refresh_token;
+			this.uid = decodeJwtSubject(this.accessToken);
 			await this._storeCredentials();
 		} catch (error) {
 			if (error.response.statusCode !== 401) {

--- a/lib/ingredient.js
+++ b/lib/ingredient.js
@@ -15,10 +15,12 @@ class Ingredient {
    * @hideconstructor
    */
 	constructor(i, {client, protobuf, uid}) {
+		this._identifier = i.identifier;
 		this._rawIngredient = i.rawIngredient;
 		this._name = i.name;
 		this._quantity = i.quantity;
 		this._note = i.note;
+		this._isHeading = i.isHeading;
 		this._client = client;
 		this._protobuf = protobuf;
 		this._uid = uid;
@@ -28,19 +30,23 @@ class Ingredient {
 
 	toJSON() {
 		return {
+			identifier: this._identifier,
 			rawIngredient: this._rawIngredient,
 			name: this._name,
 			quantity: this._quantity,
 			note: this._note,
+			isHeading: this._isHeading,
 		};
 	}
 
 	_encode() {
 		return new this._protobuf.PBIngredient({
+			identifier: this._identifier,
 			name: this._name,
 			quantity: this._quantity,
 			rawIngredient: this._rawIngredient,
 			note: this._note,
+			isHeading: this._isHeading,
 		});
 	}
 

--- a/lib/meal-planning-calendar-event.js
+++ b/lib/meal-planning-calendar-event.js
@@ -4,6 +4,14 @@ const uuid = require('./uuid');
 /// <reference path="./meal-planning-calendar-label.js" />
 /// <reference path="./recipe.js" />
 
+function formatLocalDate(date) {
+	return [
+		date.getFullYear(),
+		String(date.getMonth() + 1).padStart(2, '0'),
+		String(date.getDate()).padStart(2, '0'),
+	].join('-');
+}
+
 /**
  * Meal Planning Calendar Event class.
  * @class
@@ -70,7 +78,7 @@ class MealPlanningCalendarEvent {
 			identifier: this.identifier,
 			logicalTimestamp: this.logicalTimestamp,
 			calendarId: this._calendarId,
-			date: this.date.toISOString().slice(0, 10), // Only date, no time
+			date: formatLocalDate(this.date), // Only date, no time
 			title: this.title,
 			details: this.details,
 			recipeId: this.recipeId,

--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -60,10 +60,9 @@ class Recipe {
 		this.recipeDataId = recipeDataId;
 	}
 
-	_encode() {
-		return new this.protobuf.PBRecipe({
+	_encode(includeTimestamp = false) {
+		const payload = {
 			identifier: this.identifier,
-			timestamp: this.timestamp,
 			name: this.name,
 			note: this.note,
 			sourceName: this.sourceName,
@@ -81,7 +80,14 @@ class Recipe {
 			prepTime: this.prepTime,
 			servings: this.servings,
 			paprikaIdentifier: this.paprikaIdentifier,
-		});
+		};
+
+		if (includeTimestamp) {
+			payload.timestamp = this.timestamp;
+			payload.recipeDataId = this.recipeDataId;
+		}
+
+		return new this.protobuf.PBRecipe(payload);
 	}
 
 	/**
@@ -99,8 +105,7 @@ class Recipe {
 			userId: this.uid,
 		});
 		op.setRecipeDataId(this.recipeDataId);
-		op.setRecipe(this._encode());
-		op.setRecipeIds(this.recipeDataId);
+		op.setRecipe(this._encode(handlerId === 'remove-recipe'));
 		ops.setOperations(op);
 
 		const form = new FormData();


### PR DESCRIPTION
## Title

Fix recipe save/delete persistence by matching current AnyList web payloads

## Summary

This patch fixes recipe persistence for the unofficial AnyList client.

Before this change, recipe operations such as:

- `createRecipe(...).save()`
- editing an existing recipe and calling `save()`
- `recipe.delete()`

could return without error but fail to persist after a fresh read.

## Root cause

The current recipe operation payload no longer matches what the AnyList web client sends.

The working web payload differs in a few important ways:

1. Recipe operations include a real `userId` in metadata.
2. Recipe writes do not populate `recipeIds`.
3. Save operations use a sparse recipe payload.
4. Remove operations include `timestamp` and `recipeDataId` on the nested recipe payload.
5. Ingredient payloads include `identifier` and `isHeading`.

## What this patch changes

- Derives `uid` from the JWT `sub` claim after login / token refresh.
- Updates `Recipe._encode()` so recipe payloads match the current browser behavior more closely.
- Stops sending `recipeIds` for recipe operations.
- Includes `timestamp` and nested `recipeDataId` for `remove-recipe`.
- Preserves ingredient identifiers and `isHeading` when encoding ingredients.

## Validation

Validated against the live AnyList web app by capturing browser traffic and comparing the protobuf request bodies.

Confirmed working end-to-end after the patch:

- create recipe -> fresh search finds it
- update recipe note -> fresh read shows the new note
- delete recipe -> fresh read returns `null`

## Notes

This is based on observed current web payloads from `/data/user-recipe-data/update`. The previous implementation appears to reflect an older contract that now succeeds superficially but does not persist recipe changes.
