### PR TITLE
fix: correct categoryMatchId default and quantity proto field in Item

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -40,7 +40,7 @@ class Item {
 		this._checked = i.checked;
 		this._manualSortIndex = i.manualSortIndex;
 		this._userId = i.userId;
-		this._categoryMatchId = i.categoryMatchId || 'other';
+		this._categoryMatchId = i.categoryMatchId;
 
 		this._client = client;
 		this._protobuf = protobuf;
@@ -68,7 +68,7 @@ class Item {
 			identifier: this._identifier,
 			listId: this._listId,
 			name: this._name,
-			quantity: this._quantity,
+			deprecatedQuantity: this._quantity,
 			details: this._details,
 			checked: this._checked,
 			category: this._category,


### PR DESCRIPTION
## Summary

Two bugs in `lib/item.js` that cause incorrect behavior when adding items to a shopping list:

### 1. `categoryMatchId` hardcoded to `'other'`

The `Item` constructor defaults `categoryMatchId` to `'other'` when none is provided:

```js
// before
this._categoryMatchId = i.categoryMatchId || 'other';
```

This forces every newly created item into the "Other" category, bypassing AnyList's server-side auto-categorization. When you add "chicken breasts" to a list, AnyList knows to put it in "Meat & Seafood" — but only if `categoryMatchId` is absent from the request. Sending `'other'` overrides that.

**Fix:** don't set a fallback — let the field be `undefined` so the server assigns the category.

```js
// after
this._categoryMatchId = i.categoryMatchId;
```

### 2. `quantity` is not a valid `ListItem` proto field

`_encode()` passes `quantity: this._quantity` to the `ListItem` protobuf constructor, but `quantity` does not exist in the `ListItem` proto definition. protobufjs silently drops unrecognised fields, so the quantity value is never included in the encoded message and never reaches the API.

The correct field is `deprecatedQuantity` (proto field id 18, type `string`).

```js
// before
quantity: this._quantity,

// after
deprecatedQuantity: this._quantity,
```