### PR TITLE
feat: list/item stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Credential store
 .anylist_credentials
 
+# Local copy of anylist sorce code
+anylist-source.js
+
 # Playground
 dev.js
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -307,7 +307,19 @@ class AnyList extends EventEmitter {
 	async getLists(refreshCache = true) {
 		const decoded = await this._getUserData(refreshCache);
 
-		this.lists = decoded.shoppingListsResponse.newLists.map(list => new List(list, this));
+		const storesByListId = {};
+		for (const r of decoded.shoppingListsResponse.listResponses || []) {
+			storesByListId[r.listId] = r.stores || [];
+		}
+
+		this.lists = decoded.shoppingListsResponse.newLists.map(
+			list => new List(list, {
+				client: this.client,
+				protobuf: this.protobuf,
+				uid: this.uid,
+				stores: storesByListId[list.identifier] || []
+			}),
+		);
 
 		for (const response of decoded.starterListsResponse.recentItemListsResponse.listResponses) {
 			const list = response.starterList;

--- a/lib/item.js
+++ b/lib/item.js
@@ -42,7 +42,7 @@ class Item {
 		this._manualSortIndex = i.manualSortIndex;
 		this._userId = i.userId;
 		this._categoryMatchId = i.categoryMatchId;
-
+		this._storeIds = i.storeIds || [];
 		this._client = client;
 		this._protobuf = protobuf;
 		this._uid = uid;
@@ -61,6 +61,7 @@ class Item {
 			manualSortIndex: this._manualSortIndex,
 			userId: this._userId,
 			categoryMatchId: this._categoryMatchId,
+			storeIds: this._storeIds,
 		};
 	}
 
@@ -75,6 +76,7 @@ class Item {
 			userId: this._userId,
 			categoryMatchId: this._categoryMatchId,
 			manualSortIndex: this._manualSortIndex,
+			storeIds: this._storeIds,
 		};
 
 		// Encode quantity as quantityPb.amount per protobuf schema (must be string)
@@ -167,6 +169,10 @@ class Item {
 		this._fieldsToUpdate.push('categoryMatchId');
 	}
 
+	get storeIds() {
+		return this._storeIds;
+	}
+
 	get manualSortIndex() {
 		return this._manualSortIndex;
 	}
@@ -178,6 +184,62 @@ class Item {
 
 		this._manualSortIndex = i;
 		this._fieldsToUpdate.push('manualSortIndex');
+	}
+
+	/**
+   * Assign this item to the given stores (by store ID),
+   * or pass an empty array to clear its store assignment.
+   * AnyList tracks store assignment per store ID, so this
+   * reconciles the current set against the desired set,
+   * adding/removing individual store IDs as needed, and
+   * sends the change to AnyList's API immediately.
+   * Must set `isFavorite=true` if editing "favorites" list
+   * @param {string[]} [storeIds=[]]
+   * @param {boolean} [isFavorite=false]
+   * @return {Promise}
+   */
+	async setStores(storeIds = [], isFavorite = false) {
+		const current = this._storeIds || [];
+		const toAdd = storeIds.filter(id => !current.includes(id));
+		const toRemove = current.filter(id => !storeIds.includes(id));
+
+		const ops = [];
+
+		for (const [handlerId, ids] of [['add-list-item-store-id', toAdd], ['remove-list-item-store-id', toRemove]]) {
+			for (const storeId of ids) {
+				const op = new this._protobuf.PBListOperation();
+
+				op.setMetadata({
+					operationId: uuid(),
+					handlerId,
+					userId: this._uid,
+				});
+
+				op.setListId(this._listId);
+				op.setListItemId(this._identifier);
+				op.setUpdatedValue(storeId);
+
+				ops.push(op);
+			}
+		}
+
+		this._storeIds = storeIds;
+
+		if (ops.length === 0) {
+			return;
+		}
+
+		const opList = new this._protobuf.PBListOperationList();
+
+		opList.setOperations(ops);
+
+		const form = new FormData();
+
+		form.append('operations', opList.toBuffer());
+
+		await this._client.post(isFavorite ? 'data/starter-lists/update' : 'data/shopping-lists/update', {
+			body: form,
+		});
 	}
 
 	/**

--- a/lib/list.js
+++ b/lib/list.js
@@ -18,12 +18,13 @@ class List {
 	/**
    * @hideconstructor
    */
-	constructor(list, {client, protobuf, uid}) {
+	constructor(list, {client, protobuf, uid, stores}) {
 		this.identifier = list.identifier;
 		this.parentId = list.listId;
 		this.name = list.name;
 
 		this.items = list.items.map(i => new Item(i, {client, protobuf, uid}));
+		this.stores = stores || [];
 		this.client = client;
 		this.protobuf = protobuf;
 		this.uid = uid;
@@ -150,6 +151,15 @@ class List {
    */
 	getItemByName(name) {
 		return this.items.find(i => i.name === name);
+	}
+
+	/**
+   * Get a store on this list by name.
+   * @param {string} name store name
+   * @return {object} found store
+   */
+	findStoreByName(name) {
+		return this.stores.find(s => s.name === name);
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for associating items with specific stores within a list. The main changes add the ability to assign, update, and retrieve store assignments for items and lists, and ensure this information is sent and received properly from the AnyList API.

**Store assignment support:**

* Added a `stores` property to the `List` class and now pass store information when creating a `List` instance, allowing each list to track its available stores. (`lib/index.js`, `lib/list.js`) [[1]](diffhunk://#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1L310-R322) [[2]](diffhunk://#diff-ffa7cbeef9d06b944b6a8e6d37479ac6a925c373f6c7f7f8806eb36fcda4eca9L21-R27)
* Added a `findStoreByName` method to the `List` class to easily retrieve a store object by its name. (`lib/list.js`)

**Item-level store assignments:**

* Added a `_storeIds` property to the `Item` class to track which stores an item is assigned to, along with a getter `storeIds`. This property is included when serializing an item. (`lib/item.js`) [[1]](diffhunk://#diff-3eff69e418390369141bd57d667eac6fddec3c7ed0d4fb1526ba572e9fea159fL45-R45) [[2]](diffhunk://#diff-3eff69e418390369141bd57d667eac6fddec3c7ed0d4fb1526ba572e9fea159fR64) [[3]](diffhunk://#diff-3eff69e418390369141bd57d667eac6fddec3c7ed0d4fb1526ba572e9fea159fR79) [[4]](diffhunk://#diff-3eff69e418390369141bd57d667eac6fddec3c7ed0d4fb1526ba572e9fea159fR172-R175)
* Implemented an async `setStores` method on `Item` to assign or clear store IDs for an item, reconciling changes with the API via add/remove operations. (`lib/item.js`).

Validated that this works to add items to existing stores via my mcp server.